### PR TITLE
Added "CARD" value to the ApplicationViewType enum

### DIFF
--- a/src/main/java/com/podio/app/ApplicationViewType.java
+++ b/src/main/java/com/podio/app/ApplicationViewType.java
@@ -10,7 +10,8 @@ public enum ApplicationViewType {
 	LIST,
 	NODE,
 	CALENDAR,
-	GALLERY;
+	GALLERY,
+	CARD;
 
 	@Override
 	@JsonValue


### PR DESCRIPTION
I've added the value to the enum, which fixes when you try to get an App which has a default view of CARD.
