### PR TITLE
Add hook parameter in ItemAPI.java

### DIFF
--- a/src/main/java/com/podio/item/ItemAPI.java
+++ b/src/main/java/com/podio/item/ItemAPI.java
@@ -70,10 +70,13 @@ public class ItemAPI extends BaseAPI {
 	 *            The data for the update
 	 * @param silent
 	 *            True if the update should be silent, false otherwise
+	 * @param hook
+	 *            True if hooks should be executed for the change, false otherwise
 	 */
-	public void updateItem(int itemId, ItemUpdate update, boolean silent) {
+	public void updateItem(int itemId, ItemUpdate update, boolean silent, boolean hook) {
 		getResourceFactory().getApiResource("/item/" + itemId)
 				.queryParam("silent", silent ? "1" : "0")
+				.queryParam("hook", hook ? "1" : "0")
 				.entity(update, MediaType.APPLICATION_JSON_TYPE).put();
 	}
 
@@ -86,11 +89,14 @@ public class ItemAPI extends BaseAPI {
 	 *            The values for the fields
 	 * @param silent
 	 *            True if the update should be silent, false otherwise
+	 * @param hook
+	 *            True if hooks should be executed for the change, false otherwise
 	 */
 	public void updateItemValues(int itemId, List<FieldValuesUpdate> values,
-			boolean silent) {
+			boolean silent, boolean hook) {
 		getResourceFactory().getApiResource("/item/" + itemId + "/value/")
 				.queryParam("silent", silent ? "1" : "0")
+				.queryParam("hook", hook ? "1" : "0")
 				.entity(values, MediaType.APPLICATION_JSON_TYPE).put();
 	}
 
@@ -105,12 +111,15 @@ public class ItemAPI extends BaseAPI {
 	 *            The new values for the field
 	 * @param silent
 	 *            True if the update should be silent, false otherwise
+	 * @param hook
+	 *            True if hooks should be executed for the change, false otherwise
 	 */
 	public void updateItemFieldValues(int itemId, int fieldId,
-			List<Map<String, Object>> values, boolean silent) {
+			List<Map<String, Object>> values, boolean silent, boolean hook) {
 		getResourceFactory()
 				.getApiResource("/item/" + itemId + "/value/" + fieldId)
 				.queryParam("silent", silent ? "1" : "0")
+				.queryParam("hook", hook ? "1" : "0")
 				.entity(values, MediaType.APPLICATION_JSON_TYPE).put();
 	}
 


### PR DESCRIPTION
Hello Podio support!

In the API documentation for Items, I can see that some methods(addItem, deleteItem, updateItem) have the parameters silent and hook. In podio-java I only see the silent parameter and so I have added the hook param, but when testing this change locally I can see that the webhooks are still being executed even when setting the new hook parameter to false. Can you please review the changes as I am uncertain why it didn't work?

Thank you in advance and all the best,
Sarah
