### PR TITLE
Add support for additional parameters available in the "get organization members" API call

### DIFF
--- a/src/main/java/com/podio/org/OrgAPI.java
+++ b/src/main/java/com/podio/org/OrgAPI.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 
 import com.podio.BaseAPI;
 import com.podio.ResourceFactory;
@@ -138,6 +139,47 @@ public class OrgAPI extends BaseAPI {
 				.getApiResource("/org/" + orgId + "/member/").get(
 						new GenericType<List<OrganizationMember>>() {
 						});
+	}
+	
+	/**
+	 * Returns the members, both invited and active, of the given organization.
+	 * This method is only available for organization administrators. For users
+	 * only invited, only very limited information will be returned for the user
+	 * and profile.
+	 * 
+	 * @param orgId
+	 *            The id of the organization
+	 * @param offset
+	 *            The offset into the user list
+	 * @param limit
+	 *            The number of results to return (max 500)
+	 * @return The list of members on the organization with detailed information
+	 */
+	public List<OrganizationMember> getMembers(int orgId, int offset, int limit) {
+		return getResourceFactory()
+				.getApiResource("/org/" + orgId + "/member/")
+				.queryParam("offset", new Integer(offset).toString())
+				.queryParam("limit", new Integer(limit).toString())
+				.get(new GenericType<List<OrganizationMember>>() { });
+	}
+	
+	/**
+	 * Returns the members, both invited and active, of the given organization.
+	 * This method is only available for organization administrators. For users
+	 * only invited, only very limited information will be returned for the user
+	 * and profile.
+	 * 
+	 * @param orgId
+	 *            The id of the organization
+	 * @param options
+	 *            The parameters for get organization members
+	 * @return The list of members on the organization with detailed information
+	 */
+	public List<OrganizationMember> getMembers(int orgId, MultivaluedMap<String, String> options) {
+		return getResourceFactory()
+				.getApiResource("/org/" + orgId + "/member/")
+				.queryParams(options)
+				.get(new GenericType<List<OrganizationMember>>() { });
 	}
 
 	/**

--- a/src/main/java/com/podio/space/SpaceMemberV2.java
+++ b/src/main/java/com/podio/space/SpaceMemberV2.java
@@ -61,7 +61,7 @@ public class SpaceMemberV2 {
 	 * @param profile the profile to set
 	 */
 	@JsonProperty("profile")
-	public void setUser(Profile profile) {
+	public void setProfile(Profile profile) {
 		this.profile = profile;
 	}
 	

--- a/src/main/java/com/podio/tag/TagAPI.java
+++ b/src/main/java/com/podio/tag/TagAPI.java
@@ -104,8 +104,46 @@ public class TagAPI extends BaseAPI {
 	 */
 	public List<TagCount> getTagsOnApp(int appId) {
 		return getResourceFactory().getApiResource("/tag/app/" + appId + "/")
-				.get(new GenericType<List<TagCount>>() {
-				});
+				.get(new GenericType<List<TagCount>>() { });
+	}
+	
+	/**
+	 * Returns the tags on the given app. This includes only items. The tags are
+	 * ordered firstly by the number of uses, secondly by the tag text.
+	 * 
+	 * @param appId
+	 *            The id of the app to return tags from *
+	 * @param options
+	 *            The options for this operation, including limit on number of tags
+	 *            returned and/or text of tag to search for
+	 * @return The list of tags with their count
+	 */
+	public List<TagCount> getTagsOnApp(int appId, MultivaluedMap<String, String> options) {
+		return getResourceFactory()
+				.getApiResource("/tag/app/" + appId + "/")
+				.queryParams(options)
+				.get(new GenericType<List<TagCount>>() { });
+	}
+	
+	/**
+	 * Returns the tags on the given app. This includes only items. The tags are
+	 * ordered firstly by the number of uses, secondly by the tag text.
+	 * 
+	 * @param appId
+	 *            The id of the app to return tags from
+	 * @param limit
+	 *            limit on number of tags returned (max 250)
+	 * @param text
+	 *            text of tag to search for
+	 * @return The list of tags with their count
+	 */
+	public List<TagCount> getTagsOnApp(int appId, int limit, String text) {
+		MultivaluedMap<String, String> params=new MultivaluedMapImpl();
+		params.add("limit", new Integer(limit).toString());
+		if ((text != null) && (!text.isEmpty())) {
+			params.add("text", text);
+		}
+		return getTagsOnApp(appId, params);
 	}
 	
 	/**

--- a/src/main/java/com/podio/tag/TagAPI.java
+++ b/src/main/java/com/podio/tag/TagAPI.java
@@ -5,11 +5,13 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 
 import com.podio.BaseAPI;
 import com.podio.ResourceFactory;
 import com.podio.common.Reference;
 import com.sun.jersey.api.client.GenericType;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
 
 /**
  * Tags are words or short sentences that are used as metadata for objects. For
@@ -104,6 +106,65 @@ public class TagAPI extends BaseAPI {
 		return getResourceFactory().getApiResource("/tag/app/" + appId + "/")
 				.get(new GenericType<List<TagCount>>() {
 				});
+	}
+	
+	/**
+	 * Returns the tags on the given org. This includes both items and statuses on
+	 * all spaces in the organization that the user is part of. The tags are first
+	 * limited ordered by their frequency of use, and then returned sorted
+	 * alphabetically.
+	 * 
+	 * @param orgId
+	 *            The id of the org to return tags from
+	 * @return The list of tags with their count
+	 */
+	public List<TagCount> getTagsOnOrg(int orgId) {
+		return getResourceFactory()
+				.getApiResource("/tag/org/" + orgId + "/")
+				.get(new GenericType<List<TagCount>>() { });
+	}
+	
+	/**
+	 * Returns the tags on the given org. This includes both items and statuses on
+	 * all spaces in the organization that the user is part of. The tags are first
+	 * limited ordered by their frequency of use, and then returned sorted
+	 * alphabetically.
+	 * 
+	 * @param orgId
+	 *            The id of the org to return tags from
+	 * @param options
+	 *            The options for this operation, including limit on number of tags
+	 *            returned and/or text of tag to search for
+	 * @return The list of tags with their count
+	 */
+	public List<TagCount> getTagsOnOrg(int orgId, MultivaluedMap<String, String> options) {
+		return getResourceFactory()
+				.getApiResource("/tag/org/" + orgId + "/")
+				.queryParams(options)
+				.get(new GenericType<List<TagCount>>() { });
+	}
+	
+	/**
+	 * Returns the tags on the given org. This includes both items and statuses on
+	 * all spaces in the organization that the user is part of. The tags are first
+	 * limited ordered by their frequency of use, and then returned sorted
+	 * alphabetically.
+	 * 
+	 * @param orgId
+	 *            The id of the org to return tags from
+	 * @param limit
+	 *            limit on number of tags returned (max 250)
+	 * @param text
+	 *            text of tag to search for
+	 * @return The list of tags with their count
+	 */
+	public List<TagCount> getTagsOnOrg(int orgId, int limit, String text) {
+		MultivaluedMap<String, String> params=new MultivaluedMapImpl();
+		params.add("limit", new Integer(limit).toString());
+		if ((text != null) && (!text.isEmpty())) {
+			params.add("text", text);
+		}
+		return getTagsOnOrg(orgId, params);
 	}
 
 	/**

--- a/src/main/java/com/podio/tag/TagAPI.java
+++ b/src/main/java/com/podio/tag/TagAPI.java
@@ -200,6 +200,24 @@ public class TagAPI extends BaseAPI {
 				.get(new GenericType<List<TagReference>>() {
 				});
 	}
+	
+	/**
+	 * Returns the objects that are tagged with the given text on the org. The
+	 * objects are returned sorted descending by the time the tag was added.
+	 * 
+	 * @param orgId
+	 *            The id of the org to search within
+	 * @param text
+	 *            The tag to search for
+	 * @return The list of objects in the org that have the given tag
+	 */
+	public List<TagReference> getTagsOnOrgWithText(int orgId, String text) {
+		return getResourceFactory()
+				.getApiResource("/tag/org/" + orgId + "/search/")
+				.queryParam("text", text)
+				.get(new GenericType<List<TagReference>>() {
+				});
+	}
 
 	/**
 	 * Returns the objects that are tagged with the given text on the space. The

--- a/src/main/java/com/podio/tag/TagAPI.java
+++ b/src/main/java/com/podio/tag/TagAPI.java
@@ -215,10 +215,50 @@ public class TagAPI extends BaseAPI {
 	 * @return The list of tags with their count
 	 */
 	public List<TagCount> getTagsOnSpace(int spaceId) {
-		return getResourceFactory().getApiResource(
-				"/tag/space/" + spaceId + "/").get(
-				new GenericType<List<TagCount>>() {
-				});
+		return getResourceFactory()
+				.getApiResource("/tag/space/" + spaceId + "/")
+				.get(new GenericType<List<TagCount>>() { });
+	}
+
+	/**
+	 * Returns the tags on the given space. This includes both items and
+	 * statuses. The tags are ordered firstly by the number of uses, secondly by
+	 * the tag text.
+	 * 
+	 * @param spaceId
+	 *            The id of the space to return tags from
+	 * @param options
+	 *            The options for this operation, including limit on number of tags
+	 *            returned and/or text of tag to search for
+	 * @return The list of tags with their count
+	 */
+	public List<TagCount> getTagsOnSpace(int spaceId, MultivaluedMap<String, String> options) {
+		return getResourceFactory()
+				.getApiResource("/tag/space/" + spaceId + "/")
+				.queryParams(options)
+				.get(new GenericType<List<TagCount>>() { });
+	}
+	
+	/**
+	 * Returns the tags on the given space. This includes both items and
+	 * statuses. The tags are ordered firstly by the number of uses, secondly by
+	 * the tag text.
+	 * 
+	 * @param spaceId
+	 *            The id of the space to return tags from
+	 * @param limit
+	 *            limit on number of tags returned (max 250)
+	 * @param text
+	 *            text of tag to search for
+	 * @return The list of tags with their count
+	 */
+	public List<TagCount> getTagsOnSpace(int spaceId, int limit, String text) {
+		MultivaluedMap<String, String> params=new MultivaluedMapImpl();
+		params.add("limit", new Integer(limit).toString());
+		if ((text != null) && (!text.isEmpty())) {
+			params.add("text", text);
+		}
+		return getTagsOnSpace(spaceId, params);
 	}
 
 	/**

--- a/src/main/java/com/podio/task/TaskAPI.java
+++ b/src/main/java/com/podio/task/TaskAPI.java
@@ -152,12 +152,30 @@ public class TaskAPI extends BaseAPI {
 	 * 
 	 * @param task
 	 *            The data of the task to be created
+	 * @param silent
+	 *            Disable notifications
 	 * @return The id of the newly created task
 	 */
 	public int createTask(TaskCreate task, boolean silent) {
+		return createTask(task, silent, true);
+	}
+	
+	/**
+	 * Creates a new task with no reference to other objects.
+	 * 
+	 * @param task
+	 *            The data of the task to be created
+	 * @param silent
+	 *            Disable notifications
+	 * @param hook
+	 *            Execute hooks for the change
+	 * @return The id of the newly created task
+	 */
+	public int createTask(TaskCreate task, boolean silent, boolean hook) {
 		TaskCreateResponse response = getResourceFactory()
 				.getApiResource("/task/")
 				.queryParam("silent", silent ? "1" : "0")
+				.queryParam("hook", hook ? "1" : "0")
 				.entity(task, MediaType.APPLICATION_JSON_TYPE)
 				.post(TaskCreateResponse.class);
 

--- a/src/main/java/com/podio/task/TaskAPI.java
+++ b/src/main/java/com/podio/task/TaskAPI.java
@@ -189,15 +189,36 @@ public class TaskAPI extends BaseAPI {
 	 *            The data of the task to be created
 	 * @param reference
 	 *            The reference to the object the task should be attached to
+	 * @param silent
+	 *            Disable notifications
 	 * @return The id of the newly created task
 	 */
 	public int createTaskWithReference(TaskCreate task, Reference reference,
 			boolean silent) {
+		return createTaskWithReference(task, reference, silent, true);
+	}
+	
+	/**
+	 * Creates a new task with a reference to the given object.
+	 * 
+	 * @param task
+	 *            The data of the task to be created
+	 * @param reference
+	 *            The reference to the object the task should be attached to
+	 * @param silent
+	 *            Disable notifications
+	 * @param hook
+	 *            Execute hooks for the change
+	 * @return The id of the newly created task
+	 */
+	public int createTaskWithReference(TaskCreate task, Reference reference,
+			boolean silent, boolean hook) {
 		return getResourceFactory()
 				.getApiResource(
 						"/task/" + reference.getType().name().toLowerCase()
 								+ "/" + reference.getId() + "/")
 				.queryParam("silent", silent ? "1" : "0")
+				.queryParam("hook", hook ? "1" : "0")
 				.entity(task, MediaType.APPLICATION_JSON_TYPE)
 				.post(TaskCreateResponse.class).getId();
 	}


### PR DESCRIPTION
Overloaded getMembers method in OrgAPI, adding support for additional parameters available in the "get organization members" API call.