### PR TITLE
Implemented a way how to watch the current api usage (rate limits)

### DIFF
--- a/src/main/java/com/podio/RateLimitFilter.java
+++ b/src/main/java/com/podio/RateLimitFilter.java
@@ -3,15 +3,41 @@ package com.podio;
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.filter.ClientFilter;
+import java.util.List;
+import javax.ws.rs.core.MultivaluedMap;
 
 public class RateLimitFilter extends ClientFilter {
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public ClientResponse handle(ClientRequest cr) {
-                ClientResponse response = getNext().handle(cr);
-                RateLimits.setLimit(Integer.parseInt(response.getHeaders().get("X-Rate-Limit-Limit").get(0)));
-                RateLimits.setRemaining(Integer.parseInt(response.getHeaders().get("X-Rate-Limit-Remaining").get(0)));
-                return response;
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public ClientResponse handle(ClientRequest cr) {
+            ClientResponse response = getNext().handle(cr);
+            MultivaluedMap<String, String> headers = response.getHeaders();
+            if (headers != null) {
+                    List<String> limitHeader = headers.get("X-Rate-Limit-Limit");
+                    if (limitHeader != null && limitHeader.size() == 1) {
+                            try {
+                                    RateLimits.setLimit(Integer.parseInt(limitHeader.get(0)));
+                            } catch (NumberFormatException nfe) {
+                                    RateLimits.setLimit(null);
+                            }
+                    } else {
+                            RateLimits.setLimit(null);
+                    }
+                    List<String> remainingHeader = response.getHeaders().get("X-Rate-Limit-Remaining");
+                    if (remainingHeader != null && remainingHeader.size() == 1) {
+                            try {
+                                    RateLimits.setRemaining(Integer.parseInt(remainingHeader.get(0)));
+                            } catch (NumberFormatException nfe) {
+                                    RateLimits.setRemaining(null);
+                            }
+                    } else {
+                            RateLimits.setRemaining(null);
+                    }
+            } else {
+                    RateLimits.setLimit(null);
+                    RateLimits.setRemaining(null);
+            }
+            return response;
+    }
 }

--- a/src/main/java/com/podio/RateLimitFilter.java
+++ b/src/main/java/com/podio/RateLimitFilter.java
@@ -8,36 +8,36 @@ import javax.ws.rs.core.MultivaluedMap;
 
 public class RateLimitFilter extends ClientFilter {
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public ClientResponse handle(ClientRequest cr) {
-            ClientResponse response = getNext().handle(cr);
-            MultivaluedMap<String, String> headers = response.getHeaders();
-            if (headers != null) {
-                    List<String> limitHeader = headers.get("X-Rate-Limit-Limit");
-                    if (limitHeader != null && limitHeader.size() == 1) {
-                            try {
-                                    RateLimits.setLimit(Integer.parseInt(limitHeader.get(0)));
-                            } catch (NumberFormatException nfe) {
-                                    RateLimits.setLimit(null);
-                            }
-                    } else {
-                            RateLimits.setLimit(null);
-                    }
-                    List<String> remainingHeader = response.getHeaders().get("X-Rate-Limit-Remaining");
-                    if (remainingHeader != null && remainingHeader.size() == 1) {
-                            try {
-                                    RateLimits.setRemaining(Integer.parseInt(remainingHeader.get(0)));
-                            } catch (NumberFormatException nfe) {
-                                    RateLimits.setRemaining(null);
-                            }
-                    } else {
-                            RateLimits.setRemaining(null);
-                    }
-            } else {
-                    RateLimits.setLimit(null);
-                    RateLimits.setRemaining(null);
-            }
-            return response;
-    }
+        @SuppressWarnings("unchecked")
+        @Override
+        public ClientResponse handle(ClientRequest cr) {
+                ClientResponse response = getNext().handle(cr);
+                MultivaluedMap<String, String> headers = response.getHeaders();
+                if (headers != null) {
+                        List<String> limitHeader = headers.get("X-Rate-Limit-Limit");
+                        if (limitHeader != null && limitHeader.size() == 1) {
+                                try {
+                                        RateLimits.setLimit(Integer.parseInt(limitHeader.get(0)));
+                                } catch (NumberFormatException nfe) {
+                                        RateLimits.setLimit(null);
+                                }
+                        } else {
+                                RateLimits.setLimit(null);
+                        }
+                        List<String> remainingHeader = response.getHeaders().get("X-Rate-Limit-Remaining");
+                        if (remainingHeader != null && remainingHeader.size() == 1) {
+                                try {
+                                        RateLimits.setRemaining(Integer.parseInt(remainingHeader.get(0)));
+                                } catch (NumberFormatException nfe) {
+                                        RateLimits.setRemaining(null);
+                                }
+                        } else {
+                                RateLimits.setRemaining(null);
+                        }
+                } else {
+                        RateLimits.setLimit(null);
+                        RateLimits.setRemaining(null);
+                }
+                return response;
+        }
 }

--- a/src/main/java/com/podio/RateLimitFilter.java
+++ b/src/main/java/com/podio/RateLimitFilter.java
@@ -1,0 +1,17 @@
+package com.podio;
+
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.filter.ClientFilter;
+
+public class RateLimitFilter extends ClientFilter {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public ClientResponse handle(ClientRequest cr) {
+                ClientResponse response = getNext().handle(cr);
+                RateLimits.setLimit(Integer.parseInt(response.getHeaders().get("X-Rate-Limit-Limit").get(0)));
+                RateLimits.setRemaining(Integer.parseInt(response.getHeaders().get("X-Rate-Limit-Remaining").get(0)));
+                return response;
+	}
+}

--- a/src/main/java/com/podio/RateLimits.java
+++ b/src/main/java/com/podio/RateLimits.java
@@ -1,0 +1,24 @@
+package com.podio;
+
+public class RateLimits {
+    
+        private static int limit;
+        private static int remaining;
+
+        public static int getLimit() {
+                return limit;
+        }
+
+        public static void setLimit(int limit) {
+                RateLimits.limit = limit;
+        }
+
+        public static int getRemaining() {
+                return remaining;
+        }
+
+        public static void setRemaining(int remaining) {
+                RateLimits.remaining = remaining;
+        }
+    
+}

--- a/src/main/java/com/podio/RateLimits.java
+++ b/src/main/java/com/podio/RateLimits.java
@@ -1,24 +1,37 @@
 package com.podio;
 
 public class RateLimits {
-    
-        private static int limit;
-        private static int remaining;
 
-        public static int getLimit() {
+        private static Integer limit;
+        private static Integer remaining;
+
+        /**
+         * Returns the ceiling for the request you just made. May be null if
+         * there is no limit.
+         *
+         * @return the ceiling for the request you just made
+         */
+        public static Integer getLimit() {
                 return limit;
         }
 
-        public static void setLimit(int limit) {
+        public static void setLimit(Integer limit) {
                 RateLimits.limit = limit;
         }
 
-        public static int getRemaining() {
+        /**
+         * Returns the number of requests you have left for the current 1 hour
+         * window. May be null if there is no limit.
+         *
+         * @return the number of requests you have left for the current 1 hour
+         * window
+         */
+        public static Integer getRemaining() {
                 return remaining;
         }
 
-        public static void setRemaining(int remaining) {
+        public static void setRemaining(Integer remaining) {
                 RateLimits.remaining = remaining;
         }
-    
+
 }

--- a/src/main/java/com/podio/ResourceFactory.java
+++ b/src/main/java/com/podio/ResourceFactory.java
@@ -62,6 +62,7 @@ public final class ResourceFactory {
 		Client client = Client.create(config);
 		client.addFilter(new GZIPContentEncodingFilter(false));
 		client.addFilter(new ExceptionFilter());
+		client.addFilter(new RateLimitFilter());
 		if (dryRun) {
 			client.addFilter(new DryRunFilter());
 		}


### PR DESCRIPTION
It was a problem for me to watch the api usage (get the data from http headers). Finally I figured it out and here it is. I couldn't think of any concept how to save the data and I didn't need to store them. So I just look at the integers and print them out after every api call. If you have any idea how to make it better and more useful, please tell me.